### PR TITLE
[BG] Changed some string to ReadOnlySpan<char>
& Finished TokenizeString()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 
 bin/
 
+#Tests.cs
 obj/Debug/netcoreapp2.2/cssparser.dll
 obj/Debug/netcoreapp2.2/cssparser.pdb
-
-#Tests.cs

--- a/Token.cs
+++ b/Token.cs
@@ -9,23 +9,26 @@ public enum Tokens {
 }
 
 public class Token {
-    public string representation;
+    public System.Text.StringBuilder representation;
 
     public Tokens token;
 
     public Token(string codePoints, Tokens token) {
-        representation = codePoints;
+        representation = new System.Text.StringBuilder(codePoints);
         this.token = token;
+    }
+    public string GetRepresentation() {
+        return representation.ToString();
+    }
+
+    public void SetToken(Tokens newToken) {
+        token = newToken;
     }
 }
 
 public class ComplexToken : Token {
-    public new string representation;
 
-    public ComplexToken(string codePoints, Tokens token) : base(codePoints, token) {
-        representation = codePoints;
-        this.token = token;
-    }
+    public ComplexToken(string codePoints, Tokens token) : base(codePoints, token) { }
 }
 
 public class StringToken : ComplexToken {
@@ -34,7 +37,11 @@ public class StringToken : ComplexToken {
     public StringToken(string codePoints) : base(codePoints, Tokens.stringToken) {}
 
     public void Add(char representationChar) {
-        representation += representationChar;
+        representation.Append(representationChar);
+    }
+
+    public void Add(string representationString) {
+        representation.Append(representationString);
     }
 }
 


### PR DESCRIPTION
/!\ Pull request introducing breaking changes /!\

In this pull request, I changed some string that would often be Split()ed or Substring()ed to ReadOnlySpan<char> ([documentation](https://docs.microsoft.com/fr-fr/dotnet/api/system.readonlyspan-1?view=netcore-2.2))

I also finished the function TokenizeString(), but it still need some stronger test

Oh and modified .gitignore to try to ignore cssparser.dll and cssparser.pdb but doesn't seem to work :/